### PR TITLE
Install Python 3.7 and 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM quay.io/pypa/manylinux1_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64
 ADD ci ci
 RUN sh ci/install_deps.sh
-RUN rm netcdf4-4.1.2-23.1.x86_64.rpm
-RUN rm netcdf4-devel-4.1.2-23.1.x86_64.rpm
 RUN bash ci/install_miniconda.sh
 
 # Do not set env below to force using system gcc

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,1 +1,1 @@
-docker build . -t hainm/pytraj-build-box
+docker build . -t hainm/pytraj-build-box:2020-04-24

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,19 +1,17 @@
 #!/bin/sh
 
-for PYVER in cp27-cp27mu cp27-cp27m cp34-cp34m cp35-cp35m cp36-cp36m; do
+for PYVER in cp27-cp27mu cp27-cp27m cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38; do
     echo ${PYVER}
     export PYBIN=/opt/python/${PYVER}/bin
     export PATH=$PYBIN:$PATH
     echo ${PYVER}
-    
     ${PYBIN}/python --version
-    ${PYBIN}/python -m pip install --upgrade pip
-    ${PYBIN}/python -m pip install cython
+    ${PYBIN}/python -m pip install --upgrade pip setuptools
+    ${PYBIN}/python -m pip install Cython
     ${PYBIN}/python -m pip install numpy
+    ${PYBIN}/python -m pip install auditwheel
 done
 
-netcdf=ftp://ftp.pbone.net/mirror/ftp5.gwdg.de/pub/opensuse/repositories/home:/marcindulak/CentOS_CentOS-5/x86_64/netcdf4-4.1.2-23.1.x86_64.rpm
-netcdfdev=ftp://ftp.pbone.net/mirror/ftp5.gwdg.de/pub/opensuse/repositories/home:/marcindulak/CentOS_CentOS-5/x86_64/netcdf4-devel-4.1.2-23.1.x86_64.rpm
 yum -y install bzip2
 yum -y install blas-devel
 yum -y install lapack-devel
@@ -23,8 +21,6 @@ yum -y install bzip2-devel
 yum -y install gfortran
 yum -y install libgfortran
 yum -y install fftw3-devel
-wget $netcdf
-wget $netcdfdev
-rpm -i ./netcdf4-4.1.2-23.1.x86_64.rpm
-rpm -i ./netcdf4-devel-4.1.2-23.1.x86_64.rpm
-
+yum -y install netcdf
+yum -y install netcdf-devel
+yum -y install wget

--- a/ci/install_miniconda.sh
+++ b/ci/install_miniconda.sh
@@ -5,7 +5,7 @@ bash miniconda.sh -b
 export PATH=$HOME/miniconda3/bin:$PATH
 export LD_LIBRARY_PATH=$HOME/miniconda3/lib:$LD_LIBRARY_PATH
 
-conda install -y  \
+conda install -y \
     cython \
     conda-build \
     numpy \
@@ -13,6 +13,8 @@ conda install -y  \
     openblas \
     zlib \
     bzip2 \
-    libnetcdf \
-    libgfortran \
-    gcc
+    libnetcdf
+
+conda install -y -c conda-forge \
+    libgfortran-ng \
+    libgcc-ng


### PR DESCRIPTION
This required the following fixes:

The ftp site to download netcdf packages for centos 5 is unresponsive, and official packages for netcdf are only available for centos 7. Upgrade Docker image to centos 7 (manylinux2014).

Install missing Python packages needed to build pytraj releases.

Add specific tag to the docker image to enable versioning of the final Docker image instead of just overwriting 'latest'.